### PR TITLE
added use fixture loader option

### DIFF
--- a/src/VIPSoft/DoctrineDataFixturesExtension/Extension.php
+++ b/src/VIPSoft/DoctrineDataFixturesExtension/Extension.php
@@ -55,6 +55,9 @@ class Extension implements ExtensionInterface
                 ->arrayNode('fixtures')
                     ->prototype('scalar')->end()
                 ->end()
+                ->booleanNode('use_fixture_loader')
+                    ->defaultValue(false)
+                ->end()
                 ->scalarNode('lifetime')
                     ->defaultValue('feature')
                     ->validate()
@@ -90,6 +93,7 @@ class Extension implements ExtensionInterface
         $container->setParameter('behat.doctrine_data_fixtures.lifetime', $config['lifetime']);
         $container->setParameter('behat.doctrine_data_fixtures.migrations', $config['migrations']);
         $container->setParameter('behat.doctrine_data_fixtures.use_backup', $config['use_backup']);
+        $container->setParameter('behat.doctrine_data_fixtures.use_fixture_loader', $config['use_fixture_loader']);
     }
 
     /**

--- a/src/VIPSoft/DoctrineDataFixturesExtension/Service/FixtureService.php
+++ b/src/VIPSoft/DoctrineDataFixturesExtension/Service/FixtureService.php
@@ -59,6 +59,7 @@ class FixtureService
         $this->directories = $container->getParameter('behat.doctrine_data_fixtures.directories');
         $this->migrations = $container->getParameter('behat.doctrine_data_fixtures.migrations');
         $this->useBackup = $container->getParameter('behat.doctrine_data_fixtures.use_backup');
+        $this->useFixtureLoader = $container->getParameter('behat.doctrine_data_fixtures.use_fixture_loader');
         $this->kernel = $kernel;
 
         if ($this->useBackup) {
@@ -100,7 +101,12 @@ class FixtureService
      */
     private function getFixtureLoader()
     {
+
         $container = $this->kernel->getContainer();
+
+        if ($this->useFixtureLoader && $container->get('test.service_container')->has('doctrine.fixtures.loader')) {
+            return $container->get('test.service_container')->get('doctrine.fixtures.loader');
+        }
 
         $loader = class_exists(FixtureLoader::class)
             ? new FixtureLoader($container)


### PR DESCRIPTION
use container service objects for fixtures

Hi @yceruto,

Can you please review and merge this PR as want to use service container objects of fixtures rather then creating with new $class() as its not working when we have constructor dependencies in Fixture classes. 

Let me know if there are any feedback. 

thanks,

 