### PR TITLE
fix compatibility with latest Doctrine libs

### DIFF
--- a/src/VIPSoft/DoctrineDataFixturesExtension/Service/FixtureService.php
+++ b/src/VIPSoft/DoctrineDataFixturesExtension/Service/FixtureService.php
@@ -304,7 +304,7 @@ class FixtureService
      */
     private function dispatchEvent($em, $event)
     {
-        $eventArgs = new LifecycleEventArgs(null, $em);
+        $eventArgs = new LifecycleEventArgs(new \stdClass(), $em);
 
         $em->getEventManager()
             ->dispatchEvent($event, $eventArgs);
@@ -494,6 +494,10 @@ class FixtureService
         $em->clear();
 
         $this->referenceRepository = null;
+
+        if (!is_callable([$em->getMetadataFactory(), 'getCacheDriver'])) {
+            return;
+        }
 
         $cacheDriver = $em->getMetadataFactory()->getCacheDriver();
 


### PR DESCRIPTION
To make this library work with the latest Doctrine libraries (e.g. DBAL v3), we need to fix two points:

* the constructor for LifecycleEventArgs doesn't accept a null object anymore
* the handling of the cache was changed

This PR addresses both